### PR TITLE
Add Yolo Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 # Other stuff
 wandb
 outputs
+
+# outputs
+outputs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+default_language_version:
+    python: python3
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.4.9
+    hooks:
+    -   id: ruff
+        types_or: [ python, pyi, jupyter ]
+        args: [ --fix ]
+    -   id: ruff-format
+        types_or: [ python, pyi, jupyter ]

--- a/README.md
+++ b/README.md
@@ -3,17 +3,21 @@ A quick-and-dirty vision-based object tracker for in-hand manipulation.
 
 ## Installation
 1. Clone the repository
-2. Install CUDA 11.8 from the conda channel:
+2. Create a conda environment. If doing data generation, you must be on version 3.10, as Kubric relies on some Blender features which depend on the pinned version `bpy==3.6.0`, which requires python 3.10.
+```
+conda create -n perseus python=3.10
+conda activate perseus
+```
+3. Install CUDA 11.8 from the conda channel:
 ```conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit```
-3. Install the package:
-```pip install -e .[dev]```
-4. Pull+install the kubric submodule:
+4. If doing data generation, pull the kubric submodule:
 ```
 git submodule update --init --recursive
-cd kubric
-pip install -e .
 ```
-5. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
+5. Install the package:
+```pip install -e .[dev]```
+6. For data generation, there are some additional assets that must be downloaded and placed in the `data_generation/assets` folder: GSO, HDRI_haven, and KuBasic. The assets as well as accompanying json files should be downloaded there, which you can do by running the appropriate download scripts in `kubric/kubric/scripts` and sorting through the results. You need to modify the `data_dir` field of these json files to point to the correct path - we recommend using an absolute path here to avoid confusion.
+7. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
 
 ## Usage
 Everything in this repo uses tyro. All instructions here assume you're in the repo root.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,27 @@ python perseus/detector/train.py
 # to see the help message:
 python perseus/detector/train.py -h
 ```
+
+To generate data:
+```
+# generates 2.5k videos each with 24 frames
+python generate_all_videos.py
+
+# generates labels from all the frames
+python generate_and_label_keypoints.py --job-dir <generated_data_dir>
+```
+For example, `generated_data_dir` might look like
+```
+/path/to/perseus/data/2024-08-19_11-23-17
+```
+IMPORTANT: before running `generate_and_label_keypoints.py`, copy create a file named `mjc_keypoints.json` in `<generated_data_dir>` with the following contents:
+```
+[[-1, -1, -1], [-1, -1, 1], [-1, 1, -1], [-1, 1, 1],
+ [1, -1, -1], [1, -1, 1], [1, 1, -1], [1, 1, 1]]
+```
+This will place the keypoints at the corners of the cube.
+
+To merge multiple datasets, edit the paths to the hdf5 files you want merged in the `merge_hdf5.py` script in the `data` subdirectory, and run:
+```
+python /path/to/perseus/data/merge_hdf5.py
+```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For example, `generated_data_dir` might look like
 ```
 /path/to/perseus/data/2024-08-19_11-23-17
 ```
-IMPORTANT: before running `generate_and_label_keypoints.py`, copy create a file named `mjc_keypoints.json` in `<generated_data_dir>` with the following contents:
+IMPORTANT: before running `generate_and_label_keypoints.py`, create a file named `mjc_keypoints.json` in `<generated_data_dir>` with the following contents:
 ```
 [[-1, -1, -1], [-1, -1, 1], [-1, 1, -1], [-1, 1, 1],
  [1, -1, -1], [1, -1, 1], [1, 1, -1], [1, 1, 1]]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python perseus/detector/train.py
 python perseus/detector/train.py -h
 ```
 
-To generate data:
+To generate data, run the following in the `data_generation` directory:
 ```
 # generates 2.5k videos each with 24 frames
 python generate_all_videos.py

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # perseus
-A quick-and-dirty vision-based object tracker for in-hand manipulation. 
+A quick-and-dirty vision-based object tracker for in-hand manipulation.
 
 ## Installation
 1. Clone the repository
 2. Install CUDA 11.8 from the conda channel:
 ```conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit```
-3. Install the remaining dependencies:
-```pip install -r requirements.txt```
-4. Install the package:
-```pip install -e .```
-5. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
+3. Install the package:
+```pip install -e .[dev]```
+4. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
+
+## Usage
+Everything in this repo uses tyro. All instructions here assume you're in the repo root.
+
+To train:
+```
+# default training values
+python perseus/detector/train.py
+
+# to see the help message:
+python perseus/detector/train.py -h
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ A quick-and-dirty vision-based object tracker for in-hand manipulation.
 ```conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit```
 3. Install the package:
 ```pip install -e .[dev]```
-4. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
+4. Pull+install the kubric submodule:
+```
+git submodule update --init --recursive
+cd kubric
+pip install -e .
+```
+5. Install the ZED SDK from the official website: https://www.stereolabs.com/developers/release/
 
 ## Usage
 Everything in this repo uses tyro. All instructions here assume you're in the repo root.

--- a/data/merge_hdf5.py
+++ b/data/merge_hdf5.py
@@ -76,6 +76,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
     all_images = []
     all_depth_images = []
     all_segmentation_images = []
+    all_asset_ids = []
     all_pixel_coordinates = []
     all_object_poses = []
     all_object_scales = []
@@ -103,6 +104,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
             all_images.append(f["train"]["images"][()])
             all_depth_images.append(f["train"]["depth_images"][()])
             all_segmentation_images.append(f["train"]["segmentation_images"][()])
+            all_asset_ids.append(f["train"]["asset_ids"][()])
             all_pixel_coordinates.append(f["train"]["pixel_coordinates"][()])
             all_object_poses.append(f["train"]["object_poses"][()])
             all_object_scales.append(f["train"]["object_scales"][()])
@@ -113,6 +115,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
             all_images.append(f["test"]["images"][()])
             all_depth_images.append(f["test"]["depth_images"][()])
             all_segmentation_images.append(f["test"]["segmentation_images"][()])
+            all_asset_ids.append(f["test"]["asset_ids"][()])
             all_pixel_coordinates.append(f["test"]["pixel_coordinates"][()])
             all_object_poses.append(f["test"]["object_poses"][()])
             all_object_scales.append(f["test"]["object_scales"][()])
@@ -124,6 +127,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
     all_images = np.concatenate(all_images, axis=0)
     all_depth_images = np.concatenate(all_depth_images, axis=0)
     all_segmentation_images = np.concatenate(all_segmentation_images, axis=0)
+    all_asset_ids = np.concatenate(all_asset_ids, axis=0)
     all_pixel_coordinates = np.concatenate(all_pixel_coordinates, axis=0)
     all_object_poses = np.concatenate(all_object_poses, axis=0)
     all_object_scales = np.concatenate(all_object_scales, axis=0)
@@ -140,6 +144,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
     train_images = all_images[train_indices]
     train_depth_images = all_depth_images[train_indices]
     train_segmentation_images = all_segmentation_images[train_indices]
+    train_asset_ids = all_asset_ids[train_indices]
     train_pixel_coordinates = all_pixel_coordinates[train_indices]
     train_object_poses = all_object_poses[train_indices]
     train_object_scales = all_object_scales[train_indices]
@@ -149,6 +154,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
     test_images = all_images[test_indices]
     test_depth_images = all_depth_images[test_indices]
     test_segmentation_images = all_segmentation_images[test_indices]
+    test_asset_ids = all_asset_ids[test_indices]
     test_pixel_coordinates = all_pixel_coordinates[test_indices]
     test_object_poses = all_object_poses[test_indices]
     test_object_scales = all_object_scales[test_indices]
@@ -196,6 +202,7 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
         train.create_dataset("images", data=train_images)
         train.create_dataset("depth_images", data=train_depth_images)
         train.create_dataset("segmentation_images", data=train_segmentation_images)
+        train.create_dataset("asset_ids", data=train_asset_ids)
         train.create_dataset("pixel_coordinates", data=train_pixel_coordinates)
         train.create_dataset("object_poses", data=train_object_poses)
         train.create_dataset("object_scales", data=train_object_scales)
@@ -208,6 +215,9 @@ def merge(hdf5_list: list, output_dir: str, new_train_frac: float = 0.95) -> Non
         # test data
         test = f.create_group("test")
         test.create_dataset("images", data=test_images)
+        test.create_dataset("depth_images", data=test_depth_images)
+        test.create_dataset("segmentation_images", data=test_segmentation_images)
+        test.create_dataset("asset_ids", data=test_asset_ids)
         test.create_dataset("pixel_coordinates", data=test_pixel_coordinates)
         test.create_dataset("object_poses", data=test_object_poses)
         test.create_dataset("object_scales", data=test_object_scales)
@@ -226,6 +236,10 @@ if __name__ == "__main__":
         f"{ROOT}/data/qwerty4/mjc_data.hdf5",
         f"{ROOT}/data/qwerty5/mjc_data.hdf5",
         f"{ROOT}/data/qwerty6/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty7/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty8/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty9/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty10/mjc_data.hdf5",
     ]
     output_dir = f"{ROOT}/data/merged"
     merge(hdf5_list, output_dir)

--- a/data/merge_hdf5.py
+++ b/data/merge_hdf5.py
@@ -114,10 +114,13 @@ def merge(hdf5_list: list) -> None:  # noqa: PLR0915
         test.create_dataset("camera_poses", data=test_camera_poses)
         test.create_dataset("camera_intrinsics", data=test_camera_intrinsics)
         test.create_dataset("image_filenames", data=test_image_filenames)
-        breakpoint()
 
 
 if __name__ == "__main__":
-    hdf5_list = [f"{ROOT}/data/qwerty_aggregated/mjc_data.hdf5", f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5"]
+    hdf5_list = [
+        f"{ROOT}/data/qwerty_aggregated/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5",
+        f"{ROOT}/data/qwerty_aggregated3/mjc_data.hdf5",
+    ]
     merge(hdf5_list)
     print("Merging complete.")

--- a/data/merge_hdf5.py
+++ b/data/merge_hdf5.py
@@ -1,16 +1,68 @@
 import itertools
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import h5py
 import numpy as np
+from PIL import Image
+from tqdm import tqdm
 
 from perseus import ROOT
 
 
-def merge(hdf5_list: list) -> None:  # noqa: PLR0915
+def save_image(image_data: tuple) -> str:
+    """Save an image to disk.
+
+    Args:
+        image_data: tuple containing the image and the output path.
+
+    Returns:
+        output_path: path to the saved image.
+    """
+    image, output_path = image_data
+    image = Image.fromarray(image)
+    image.save(output_path)
+    return output_path
+
+
+def save_images_in_parallel(images: list, output_dir: str, mode: str, start_index: int) -> list:
+    """Save images in parallel.
+
+    Args:
+        images: list of images to save.
+        output_dir: directory to save the images.
+        mode: train or test.
+        start_index: starting index for the image filenames.
+
+    Returns:
+        filenames: list of saved image filenames.
+    """
+    filenames = []
+    image_data = []
+    i = start_index
+
+    for img_batch in images:
+        for image in img_batch:
+            output_path = f"{output_dir}/images/{mode}/img{i:08d}.png"
+            image_data.append((image, output_path))
+            i += 1
+
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(save_image, data): data for data in image_data}
+        for future in tqdm(as_completed(futures), desc=f"Saving {mode} images", total=len(image_data)):
+            filenames.append(future.result())
+
+    return filenames
+
+
+def merge(hdf5_list: list, output_dir: str) -> None:  # noqa: PLR0915
     """Merge multiple hdf5 datasets into a larger one.
+
+    In particular, also merges all images into a new directory and updates the image filenames.
 
     Args:
         hdf5_list: list of hdf5 file paths to merge.
+        output_dir: directory to save the merged images.
     """
     # attributes
     num_keypoints = None
@@ -36,7 +88,8 @@ def merge(hdf5_list: list) -> None:  # noqa: PLR0915
     test_camera_intrinsics = []
     test_image_filenames = []
 
-    # looping through hdf5 files
+    # aggregating data
+    print("Aggregating data...")
     for file_path in hdf5_list:
         with h5py.File(file_path, "r") as f:
             # attributes
@@ -53,24 +106,23 @@ def merge(hdf5_list: list) -> None:  # noqa: PLR0915
                 W = f.attrs["W"]
 
             # train data
-            train_images.append(f["train"]["images"][:])
-            train_pixel_coordinates.append(f["train"]["pixel_coordinates"][:])
-            train_object_poses.append(f["train"]["object_poses"][:])
-            train_object_scales.append(f["train"]["object_scales"][:])
-            train_camera_poses.append(f["train"]["camera_poses"][:])
-            train_camera_intrinsics.append(f["train"]["camera_intrinsics"][:])
-            train_image_filenames.append(f["train"]["image_filenames"][:])
+            train_images.append(f["train"]["images"][()])
+            train_pixel_coordinates.append(f["train"]["pixel_coordinates"][()])
+            train_object_poses.append(f["train"]["object_poses"][()])
+            train_object_scales.append(f["train"]["object_scales"][()])
+            train_camera_poses.append(f["train"]["camera_poses"][()])
+            train_camera_intrinsics.append(f["train"]["camera_intrinsics"][()])
 
             # test data
-            test_images.append(f["test"]["images"][:])
-            test_pixel_coordinates.append(f["test"]["pixel_coordinates"][:])
-            test_object_poses.append(f["test"]["object_poses"][:])
-            test_object_scales.append(f["test"]["object_scales"][:])
-            test_camera_poses.append(f["test"]["camera_poses"][:])
-            test_camera_intrinsics.append(f["test"]["camera_intrinsics"][:])
-            test_image_filenames.append(f["test"]["image_filenames"][:])
+            test_images.append(f["test"]["images"][()])
+            test_pixel_coordinates.append(f["test"]["pixel_coordinates"][()])
+            test_object_poses.append(f["test"]["object_poses"][()])
+            test_object_scales.append(f["test"]["object_scales"][()])
+            test_camera_poses.append(f["test"]["camera_poses"][()])
+            test_camera_intrinsics.append(f["test"]["camera_intrinsics"][()])
 
     # converting to numpy
+    print("Converting to numpy...")
     train_images = np.concatenate(train_images, axis=0)
     train_pixel_coordinates = np.concatenate(train_pixel_coordinates, axis=0)
     train_object_poses = np.concatenate(train_object_poses, axis=0)
@@ -87,8 +139,22 @@ def merge(hdf5_list: list) -> None:  # noqa: PLR0915
     test_camera_intrinsics = np.concatenate(test_camera_intrinsics, axis=0)
     test_image_filenames = list(itertools.chain(*test_image_filenames))
 
+    # resaving images under a new directory
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+        os.makedirs(f"{output_dir}/images/train")
+        os.makedirs(f"{output_dir}/images/test")
+    else:
+        raise ValueError(
+            f"Directory {output_dir} already exists! For safety, please manually remove it or choose a new directory."
+        )  # TODO(ahl): deal with this in a smarter way
+
+    train_image_filenames = save_images_in_parallel(train_images, output_dir.split("/")[-1], "train", 0)
+    test_image_filenames = save_images_in_parallel(test_images, output_dir.split("/")[-1], "test", 0)
+
     # creating new dataset
-    with h5py.File("merged.hdf5", "w") as f:
+    print("Creating new dataset...")
+    with h5py.File(f"{output_dir}/merged.hdf5", "w") as f:
         # attributes
         f.attrs["num_keypoints"] = num_keypoints
         f.attrs["train_frac"] = train_frac
@@ -122,5 +188,6 @@ if __name__ == "__main__":
         f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5",
         f"{ROOT}/data/qwerty_aggregated3/mjc_data.hdf5",
     ]
-    merge(hdf5_list)
+    output_dir = f"{ROOT}/data/merged"
+    merge(hdf5_list, output_dir)
     print("Merging complete.")

--- a/data/merge_hdf5.py
+++ b/data/merge_hdf5.py
@@ -17,12 +17,12 @@ def save_image(image_data: tuple) -> str:
         image_data: tuple containing the image and the output path.
 
     Returns:
-        output_path: path to the saved image.
+        local_path: local path to the saved image (to be stored in hdf5).
     """
-    image, output_path = image_data
+    image, save_path, local_path = image_data
     image = Image.fromarray(image)
-    image.save(output_path)
-    return output_path
+    image.save(save_path)
+    return local_path
 
 
 def save_images_in_parallel(images: list, output_dir: str, mode: str, start_index: int) -> list:
@@ -43,8 +43,9 @@ def save_images_in_parallel(images: list, output_dir: str, mode: str, start_inde
 
     for img_batch in images:
         for image in img_batch:
-            output_path = f"{output_dir}/images/{mode}/img{i:08d}.png"
-            image_data.append((image, output_path))
+            save_path = f"{output_dir}/images/{mode}/img{i:08d}.png"
+            local_path = f"images/{mode}/img{i:08d}.png"
+            image_data.append((image, save_path, local_path))
             i += 1
 
     with ThreadPoolExecutor() as executor:

--- a/data/merge_hdf5.py
+++ b/data/merge_hdf5.py
@@ -1,0 +1,123 @@
+import itertools
+
+import h5py
+import numpy as np
+
+from perseus import ROOT
+
+
+def merge(hdf5_list: list) -> None:  # noqa: PLR0915
+    """Merge multiple hdf5 datasets into a larger one.
+
+    Args:
+        hdf5_list: list of hdf5 file paths to merge.
+    """
+    # attributes
+    num_keypoints = None
+    train_frac = None
+    H = None
+    W = None
+
+    # train data
+    train_images = []
+    train_pixel_coordinates = []
+    train_object_poses = []
+    train_object_scales = []
+    train_camera_poses = []
+    train_camera_intrinsics = []
+    train_image_filenames = []
+
+    # test data
+    test_images = []
+    test_pixel_coordinates = []
+    test_object_poses = []
+    test_object_scales = []
+    test_camera_poses = []
+    test_camera_intrinsics = []
+    test_image_filenames = []
+
+    # looping through hdf5 files
+    for file_path in hdf5_list:
+        with h5py.File(file_path, "r") as f:
+            # attributes
+            if num_keypoints is None:
+                num_keypoints = f.attrs["num_keypoints"]
+
+            if train_frac is None:
+                train_frac = f.attrs["train_frac"]
+
+            if H is None:
+                H = f.attrs["H"]
+
+            if W is None:
+                W = f.attrs["W"]
+
+            # train data
+            train_images.append(f["train"]["images"][:])
+            train_pixel_coordinates.append(f["train"]["pixel_coordinates"][:])
+            train_object_poses.append(f["train"]["object_poses"][:])
+            train_object_scales.append(f["train"]["object_scales"][:])
+            train_camera_poses.append(f["train"]["camera_poses"][:])
+            train_camera_intrinsics.append(f["train"]["camera_intrinsics"][:])
+            train_image_filenames.append(f["train"]["image_filenames"][:])
+
+            # test data
+            test_images.append(f["test"]["images"][:])
+            test_pixel_coordinates.append(f["test"]["pixel_coordinates"][:])
+            test_object_poses.append(f["test"]["object_poses"][:])
+            test_object_scales.append(f["test"]["object_scales"][:])
+            test_camera_poses.append(f["test"]["camera_poses"][:])
+            test_camera_intrinsics.append(f["test"]["camera_intrinsics"][:])
+            test_image_filenames.append(f["test"]["image_filenames"][:])
+
+    # converting to numpy
+    train_images = np.concatenate(train_images, axis=0)
+    train_pixel_coordinates = np.concatenate(train_pixel_coordinates, axis=0)
+    train_object_poses = np.concatenate(train_object_poses, axis=0)
+    train_object_scales = np.concatenate(train_object_scales, axis=0)
+    train_camera_poses = np.concatenate(train_camera_poses, axis=0)
+    train_camera_intrinsics = np.concatenate(train_camera_intrinsics, axis=0)
+    train_image_filenames = list(itertools.chain(*train_image_filenames))
+
+    test_images = np.concatenate(test_images, axis=0)
+    test_pixel_coordinates = np.concatenate(test_pixel_coordinates, axis=0)
+    test_object_poses = np.concatenate(test_object_poses, axis=0)
+    test_object_scales = np.concatenate(test_object_scales, axis=0)
+    test_camera_poses = np.concatenate(test_camera_poses, axis=0)
+    test_camera_intrinsics = np.concatenate(test_camera_intrinsics, axis=0)
+    test_image_filenames = list(itertools.chain(*test_image_filenames))
+
+    # creating new dataset
+    with h5py.File("merged.hdf5", "w") as f:
+        # attributes
+        f.attrs["num_keypoints"] = num_keypoints
+        f.attrs["train_frac"] = train_frac
+        f.attrs["H"] = H
+        f.attrs["W"] = W
+
+        # train data
+        train = f.create_group("train")
+        train.create_dataset("images", data=train_images)
+        train.create_dataset("pixel_coordinates", data=train_pixel_coordinates)
+        train.create_dataset("object_poses", data=train_object_poses)
+        train.create_dataset("object_scales", data=train_object_scales)
+        train.create_dataset("camera_poses", data=train_camera_poses)
+        train.create_dataset("camera_intrinsics", data=train_camera_intrinsics)
+        train.create_dataset("image_filenames", data=train_image_filenames)
+
+        # test data
+        test = f.create_group("test")
+        test.create_dataset("images", data=test_images)
+        test.create_dataset("pixel_coordinates", data=test_pixel_coordinates)
+        test.create_dataset("object_poses", data=test_object_poses)
+        test.create_dataset("object_scales", data=test_object_scales)
+        test.create_dataset("camera_poses", data=test_camera_poses)
+        test.create_dataset("camera_intrinsics", data=test_camera_intrinsics)
+        test.create_dataset("image_filenames", data=test_image_filenames)
+        breakpoint()
+
+
+if __name__ == "__main__":
+    hdf5_list = [f"{ROOT}/data/qwerty_aggregated/mjc_data.hdf5", f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5"]
+    merge(hdf5_list)
+    print("Merging complete.")

--- a/data/visualize_data.py
+++ b/data/visualize_data.py
@@ -21,9 +21,9 @@ def main(hdf5_path: Union[str, Path], mode: str = "images") -> None:
         print(f"Min pixel coordinates: {min_pixel_coordinates}")
 
         # visualizing the training data
-        for i in range(len(f["train"]["images"])):
+        for i in range(len(f["train"][f"{mode}"])):
             print(f"Image {i}")
-            images = f["train"]["images"][i]
+            images = f["train"][f"{mode}"][i]
             keypoints_all = f["train"]["pixel_coordinates"][i]
 
             for j in range(len(images)):
@@ -35,12 +35,14 @@ def main(hdf5_path: Union[str, Path], mode: str = "images") -> None:
                 plt.imshow(image)
                 for k in range(len(keypoints)):
                     plt.scatter(keypoints[k, 0], keypoints[k, 1], color=keypoint_colormap(k), marker="o")
-                plt.title(f"Image {i}/{len(f['train']['images'])} | Frame {j}/{len(images)}")
+                plt.title(f"Image {i}/{len(f['train'][f'{mode}'])} | Frame {j}/{len(images)}")
                 plt.show()
 
 
 if __name__ == "__main__":
-    hdf5_path = Path(f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5")
-    # main(hdf5_path, mode="images")
-    main(hdf5_path, mode="depth_images")
+    hdf5_path = Path(f"{ROOT}/data/merged/merged.hdf5")
+
+    # uncomment the one you want to see
+    main(hdf5_path, mode="images")
+    # main(hdf5_path, mode="depth_images")
     # main(hdf5_path, mode="segmentation_images")

--- a/data/visualize_data.py
+++ b/data/visualize_data.py
@@ -7,8 +7,9 @@ import matplotlib.pyplot as plt
 from perseus import ROOT
 
 
-def main(hdf5_path: Union[str, Path]) -> None:
+def main(hdf5_path: Union[str, Path], mode: str = "images") -> None:
     """Main function."""
+    assert mode in ["images", "depth_images", "segmentation_images"], f"Invalid mode: {mode}"
     num_keypoints = 8
     keypoint_colormap = plt.cm.get_cmap("tab10", num_keypoints)
 
@@ -40,4 +41,6 @@ def main(hdf5_path: Union[str, Path]) -> None:
 
 if __name__ == "__main__":
     hdf5_path = Path(f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5")
-    main(hdf5_path)
+    # main(hdf5_path, mode="images")
+    main(hdf5_path, mode="depth_images")
+    # main(hdf5_path, mode="segmentation_images")

--- a/data/visualize_data.py
+++ b/data/visualize_data.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Union
+
+import h5py
+import matplotlib.pyplot as plt
+
+from perseus import ROOT
+
+
+def main(hdf5_path: Union[str, Path]) -> None:
+    """Main function."""
+    num_keypoints = 8
+    keypoint_colormap = plt.cm.get_cmap("tab10", num_keypoints)
+
+    with h5py.File(hdf5_path, "r") as f:
+        # max/min pixel coordinates over whole dataset
+        max_pixel_coordinates = f["train"]["pixel_coordinates"][:].max()
+        min_pixel_coordinates = f["train"]["pixel_coordinates"][:].min()
+        print(f"Max pixel coordinates: {max_pixel_coordinates}")
+        print(f"Min pixel coordinates: {min_pixel_coordinates}")
+
+        # visualizing the training data
+        for i in range(len(f["train"]["images"])):
+            print(f"Image {i}")
+            images = f["train"]["images"][i]
+            keypoints_all = f["train"]["pixel_coordinates"][i]
+
+            for j in range(len(images)):
+                print(f"    Frame {j}")
+                image = images[j]  # (256, 256, 3)
+                keypoints = keypoints_all[j]  # (8, 2)
+
+                # Plot the image and keypoints
+                plt.imshow(image)
+                for k in range(len(keypoints)):
+                    plt.scatter(keypoints[k, 0], keypoints[k, 1], color=keypoint_colormap(k), marker="o")
+                plt.title(f"Image {i}/{len(f['train']['images'])} | Frame {j}/{len(images)}")
+                plt.show()
+
+
+if __name__ == "__main__":
+    hdf5_path = Path(f"{ROOT}/data/qwerty_aggregated2/mjc_data.hdf5")
+    main(hdf5_path)

--- a/data_generation/generate_all_videos.py
+++ b/data_generation/generate_all_videos.py
@@ -11,6 +11,8 @@ from datetime import datetime
 import tensorflow as tf
 from tqdm import tqdm
 
+from perseus import ROOT
+
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
@@ -31,7 +33,7 @@ def generate(args: argparse.Namespace) -> None:
     subprocess.run(
         [
             "python",
-            "data_generation/generate_one_video.py",
+            f"{ROOT}/data_generation/generate_one_video.py",
             "--job-dir",
             f"data/{args.run_id}/{args.job_id}",
         ],

--- a/data_generation/generate_all_videos.py
+++ b/data_generation/generate_all_videos.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import tensorflow as tf
 from tqdm import tqdm
 
+import kubric as kb
 from perseus import ROOT
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -19,7 +20,7 @@ tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 logging.getLogger().setLevel(logging.ERROR)
 
 # Setup args.
-parser = argparse.ArgumentParser()
+parser = kb.ArgumentParser()
 parser.add_argument("--num_videos", type=int, default=2500, help="Number of videos to generate.")
 parser.add_argument("--num_workers", type=int, default=8, help="Number of workers to use.")
 # TODO(pculbert): Expose all video generationn arguments.

--- a/data_generation/generate_all_videos.py
+++ b/data_generation/generate_all_videos.py
@@ -1,34 +1,29 @@
 """Script to generate all videos for the dataset."""
 
+import argparse
+import logging
 import multiprocessing
+import os
 import subprocess
 import uuid
-from tqdm import tqdm
-import kubric as kb
 from datetime import datetime
-import tensorflow as tf
 
-import os
+import tensorflow as tf
+from tqdm import tqdm
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
-import logging
-
 logging.getLogger().setLevel(logging.ERROR)
 
 # Setup args.
-parser = kb.ArgumentParser()
-parser.add_argument(
-    "--num_videos", type=int, default=2500, help="Number of videos to generate."
-)
-parser.add_argument(
-    "--num_workers", type=int, default=8, help="Number of workers to use."
-)
+parser = argparse.ArgumentParser()
+parser.add_argument("--num_videos", type=int, default=2500, help="Number of videos to generate.")
+parser.add_argument("--num_workers", type=int, default=8, help="Number of workers to use.")
 # TODO(pculbert): Expose all video generationn arguments.
 
 
-def generate(args):
+def generate(args: argparse.Namespace) -> None:
     """Generate a video."""
     # Create random hash for this video.
     args.job_id = str(uuid.uuid4())
@@ -39,7 +34,8 @@ def generate(args):
             "data_generation/generate_one_video.py",
             "--job-dir",
             f"data/{args.run_id}/{args.job_id}",
-        ]
+        ],
+        check=False,
     )
 
 

--- a/perseus/__init__.py
+++ b/perseus/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+# package root
+ROOT = str(Path(__file__).parent.parent)

--- a/perseus/detector/data.py
+++ b/perseus/detector/data.py
@@ -49,7 +49,7 @@ class AugmentationConfig:
 class KeypointDatasetConfig:
     """Configuration for the keypoint dataset."""
 
-    dataset_path: str = "data/qwerty_aggregated/mjc_data.hdf5"
+    dataset_path: str = "data/merged/merged.hdf5"
 
 
 @dataclass(frozen=True)

--- a/perseus/detector/data.py
+++ b/perseus/detector/data.py
@@ -129,7 +129,7 @@ class KeypointDataset(Dataset):
         # the segmentation image is a binary mask of the cube
         original_seg_image = self.segmentation_images[traj_idx][image_idx]
         asset_id = self.asset_ids[traj_idx][image_idx]
-        segmentation_image = torch.zeros_like(original_seg_image)
+        segmentation_image = np.zeros_like(original_seg_image)
         segmentation_image[original_seg_image == asset_id] = 1.0
         segmentation_image = kornia.utils.image_to_tensor(segmentation_image)
 

--- a/perseus/detector/loss.py
+++ b/perseus/detector/loss.py
@@ -1,0 +1,36 @@
+import numpy as np
+import torch
+
+
+def _gaussian_chol_loss_fn(pred: torch.Tensor, pixel_coordinates: torch.Tensor, n_keypoints: int) -> torch.Tensor:
+    """Loss function for the Gaussian keypoint model with 'chol' option.
+
+    Args:
+        pred: The predicted parameters of the Gaussian distribution.
+        pixel_coordinates: The pixel coordinates of the keypoints.
+        n_keypoints: The number of keypoints.
+
+    Returns:
+        The loss.
+    """
+    mu, L = pred
+    return -torch.distributions.multivariate_normal.MultivariateNormal(mu, scale_tril=L).log_prob(
+        pixel_coordinates
+    ).mean() - (n_keypoints / 2) * torch.log(torch.tensor(2 * np.pi))
+
+
+def _gaussian_diag_loss_fn(pred: torch.Tensor, pixel_coordinates: torch.Tensor, n_keypoints: int) -> torch.Tensor:
+    """Loss function for the Gaussian keypoint model with 'diag' option.
+
+    Args:
+        pred: The predicted parameters of the Gaussian distribution.
+        pixel_coordinates: The pixel coordinates of the keypoints.
+        n_keypoints: The number of keypoints.
+
+    Returns:
+        The loss.
+    """
+    mu, sigma = pred
+    return -torch.distributions.multivariate_normal.MultivariateNormal(mu, sigma).log_prob(pixel_coordinates).mean() - (
+        n_keypoints / 2
+    ) * torch.log(torch.tensor(2 * np.pi))

--- a/perseus/detector/models.py
+++ b/perseus/detector/models.py
@@ -255,7 +255,10 @@ class YOLOModel(nn.Module):
             y_o2o: tensor of predicted pixel coordinates for the one2one branch, shape=(batch_size, 2 * n_keypoints).
         """
         # yolo part
-        _detections, fpn_dicts = self.yolo_detector(x)  # [NOTE] detections unused
+        if self.training:
+            fpn_dicts = self.yolo_detector(x)
+        else:
+            _detections, fpn_dicts = self.yolo_detector(x)  # [NOTE] detections unused
         o2m_features = fpn_dicts["one2many"]  # 3-tuple of features of shape (B, 144, 32/16/8, 32/16/8)
         o2o_features = fpn_dicts["one2one"]  # 3-tuple of features of shape (B, 144, 32/16/8, 32/16/8)
 

--- a/perseus/detector/models.py
+++ b/perseus/detector/models.py
@@ -1,11 +1,27 @@
-import torch
-import torch.nn as nn
-import torchvision.models as models
+from typing import Tuple, Union
+
 import numpy as np
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import nn
+from torchvision import models
+from ultralytics.nn.autobackend import AutoBackend
+
+from perseus import ROOT
 
 
 class KeypointCNN(nn.Module):
-    def __init__(self, n_keypoints=8, num_channels=3, H=256, W=256):
+    """Default perseus keypoint CNN model trained by fine-tuning resnet."""
+
+    def __init__(self, n_keypoints: int = 8, num_channels: int = 3, H: int = 256, W: int = 256) -> None:
+        """Initialize the keypoint CNN model.
+
+        Args:
+            n_keypoints: The number of keypoints to predict.
+            num_channels: The number of channels in the input images.
+            H: The height of the input images.
+            W: The width of the input images.
+        """
         super(KeypointCNN, self).__init__()
         # Load a prebuilt ResNet (e.g., ResNet18) and modify it
         self.resnet = models.resnet18(weights="DEFAULT")
@@ -15,21 +31,24 @@ class KeypointCNN(nn.Module):
         self.W = W
 
         # Adjust the first convolutional layer if the input has a different number of channels than 3
-        if num_channels != 3:
-            self.resnet.conv1 = nn.Conv2d(
-                num_channels, 64, kernel_size=7, stride=2, padding=3, bias=False
-            )
+        if num_channels != 3:  # noqa: PLR2004
+            self.resnet.conv1 = nn.Conv2d(num_channels, 64, kernel_size=7, stride=2, padding=3, bias=False)
 
         # Replace the average pooling and the final fully connected layer
         self.resnet.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.resnet.fc = nn.Linear(self.resnet.fc.in_features, 2 * n_keypoints)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the network.
+
+        Args:
+            x: tensor of input images, shape=(batch_size, num_channels, H, W).
+        """
         return self.resnet(x)
 
 
 class KeypointGaussian(torch.nn.Module):
-    """Implementation of a keypoint CNN that returns a multivariate Gaussian over the keypoint locations in pixel coordinatess."""
+    """Keypoint CNN that returns a multivariate Gaussian over the keypoint locations in pixel coordinates."""
 
     def __init__(
         self,
@@ -38,7 +57,16 @@ class KeypointGaussian(torch.nn.Module):
         H: int = 256,
         W: int = 256,
         cov_type: str = "diag",
-    ):
+    ) -> None:
+        """Initialize the keypoint CNN model.
+
+        Args:
+            n_keypoints: The number of keypoints to predict.
+            in_channels: The number of channels in the input images.
+            H: The height of the input images.
+            W: The width of the input images.
+            cov_type: The type of covariance matrix to use. Must be one of ["diag", "chol"].
+        """
         super().__init__()
 
         self.n_keypoints = n_keypoints
@@ -62,9 +90,7 @@ class KeypointGaussian(torch.nn.Module):
         self.fc2 = torch.nn.Linear(256, 256)
 
         if cov_type == "chol":
-            self.fc3 = torch.nn.Linear(
-                256, 2 * n_keypoints + (2 * n_keypoints * (2 * n_keypoints + 1) // 2)
-            )
+            self.fc3 = torch.nn.Linear(256, 2 * n_keypoints + (2 * n_keypoints * (2 * n_keypoints + 1) // 2))
         elif cov_type == "diag":
             self.fc3 = torch.nn.Linear(256, 2 * 2 * n_keypoints)
 
@@ -81,7 +107,6 @@ class KeypointGaussian(torch.nn.Module):
         Returns:
             (batch_size, 2 * n_keypoints) tensor of predicted pixel coordinates.
         """
-
         # (batch_size, 64, H/2, W/2)
         x = self.relu(self.bn1(self.conv1(x)))
 
@@ -134,9 +159,7 @@ class KeypointGaussian(torch.nn.Module):
             )
 
             MIN_DET = 1e-8  # Minimum determinant of the covariance matrix.
-            L += np.power(MIN_DET, 1 / (2 * self.n_keypoints)) * torch.eye(
-                2 * self.n_keypoints, device=x.device
-            )
+            L += np.power(MIN_DET, 1 / (2 * self.n_keypoints)) * torch.eye(2 * self.n_keypoints, device=x.device)
             return mu, L
 
         elif self.cov_type == "diag":
@@ -146,3 +169,118 @@ class KeypointGaussian(torch.nn.Module):
             return mu, sigma
         else:
             raise ValueError(f"Invalid cov_type: {self.cov_type}")
+
+
+class YOLOModel(nn.Module):
+    """YOLO-based backbone for keypoint detection on the cube."""
+
+    def __init__(self, version: int = 10, size: str = "n", n_keypoints: int = 8) -> None:
+        """Initialize the YOLO model.
+
+        Args:
+            version: The version of YOLO to use. Must be 9 or 10.
+            size: The size of the model to use.
+                If v9, must be one of ["t", "s", "m", "c", "e"].
+                If v10, must be one of ["n", "s", "m", "l", "x"].
+            n_keypoints: The number of keypoints to predict.
+        """
+        super().__init__()
+
+        # [DEBUG] for now, only allow YOLOv10
+        assert version == 10, "[DEBUG] only allow v10 for now!"  # noqa: PLR2004
+
+        # checking types
+        if not isinstance(version, int):
+            raise ValueError(f"Invalid version: {version}. Must be an integer.")
+        if not isinstance(size, str):
+            raise ValueError(f"Invalid size: {size}. Must be a string.")
+
+        # checking values
+        if version not in [9, 10]:
+            raise ValueError(f"Invalid version: {version}. Must be one of [9, 10].")
+        if version == 9 and size not in ["t", "s", "m", "c", "e"]:  # noqa: PLR2004
+            raise ValueError(f"Invalid size: {size}. Must be one of ['t', 's', 'm', 'c', 'e'].")
+        if version == 10 and size not in ["n", "s", "m", "l", "x"]:  # noqa: PLR2004
+            raise ValueError(f"Invalid size: {size}. Must be one of ['n', 's', 'm', 'l', 'x'].")
+
+        self.version = version
+        self.n_keypoints = n_keypoints
+
+        # loading yolo model
+        model_str = ROOT + f"/outputs/yolo/yolov{version}{size}.pt"
+        yolo_model = AutoBackend(model_str, device=torch.device("cuda"))  # ultralytics AutoBackend object
+        self.yolo_detector = yolo_model.model  # ultralytics Detector object
+
+        # keypoint head
+        # The yolo model outputs 3 feature maps of shape (B, 144, 32/16/8, 32/16/8) for each of the one2many and
+        # one2one computation branches. Both branches are used during training, but only the one2one branch is used
+        # during inference.
+        self.conv32x32_o2m = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.conv16x16_o2m = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.conv8x8_o2m = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+
+        self.conv32x32_o2o = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.conv16x16_o2o = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.conv8x8_o2o = nn.Sequential(
+            nn.Conv2d(in_channels=144, out_channels=2 * n_keypoints, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+
+        self.layer_weights = nn.Parameter(torch.ones(3))
+        self.linear = nn.Linear(32 * 32, 1)  # TODO(ahl): pretty aggressive reduction here, might need to be adjusted
+
+    def forward(self, x: torch.Tensor) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Forward pass of the network.
+
+        Args:
+            x: tensor of input images, shape=(batch_size, 3, H, W).
+
+        Returns:
+            y_o2m: tensor of predicted pixel coordinates for the one2many branch, shape=(batch_size, 2 * n_keypoints).
+            y_o2o: tensor of predicted pixel coordinates for the one2one branch, shape=(batch_size, 2 * n_keypoints).
+        """
+        # yolo part
+        _detections, fpn_dicts = self.yolo_detector(x)  # [NOTE] detections unused
+        o2m_features = fpn_dicts["one2many"]  # 3-tuple of features of shape (B, 144, 32/16/8, 32/16/8)
+        o2o_features = fpn_dicts["one2one"]  # 3-tuple of features of shape (B, 144, 32/16/8, 32/16/8)
+
+        # keypoint part
+        y_o2o_32x32 = self.conv32x32_o2o(o2o_features[0])  # (B, 2 * n_keypoints, 32, 32)
+        y_o2o_16x16 = F.interpolate(self.conv16x16_o2o(o2o_features[1]), scale_factor=2)  # (B, 2 * n_keypoints, 32, 32)
+        y_o2o_8x8 = F.interpolate(self.conv8x8_o2o(o2o_features[2]), scale_factor=4)  # (B, 2 * n_keypoints, 32, 32)
+        y_o2o = (
+            self.layer_weights[0] * y_o2o_32x32
+            + self.layer_weights[1] * y_o2o_16x16
+            + self.layer_weights[2] * y_o2o_8x8
+        ) / self.layer_weights.sum()  # (B, 2 * n_keypoints, 32, 32), learned weighted average of the three scales
+        y_o2o = self.linear(y_o2o.view(*y_o2o.shape[:-2], -1)).squeeze(-1)
+
+        # only do one2many computation during training
+        if self.training:
+            y_o2m_32x32 = self.conv32x32_o2m(o2m_features[0])  # (B, 2 * n_keypoints, 32, 32)
+            y_o2m_16x16 = F.interpolate(self.conv16x16_o2m(o2m_features[1]), scale_factor=2)
+            y_o2m_8x8 = F.interpolate(self.conv8x8_o2m(o2m_features[2]), scale_factor=4)
+            y_o2m = (
+                self.layer_weights[0] * y_o2m_32x32
+                + self.layer_weights[1] * y_o2m_16x16
+                + self.layer_weights[2] * y_o2m_8x8
+            ) / self.layer_weights.sum()
+            y_o2m = self.linear(y_o2m.view(*y_o2m.shape[:-2], -1)).squeeze(-1)  # (B, 2 * n_keypoints)
+            return y_o2o, y_o2m
+
+        return y_o2o

--- a/perseus/detector/train.py
+++ b/perseus/detector/train.py
@@ -31,7 +31,7 @@ class TrainConfig:
     """Configuration for training."""
 
     # The batch size.
-    batch_size: int = 128
+    batch_size: int = 64
 
     # The (initial) learning rate set in the optimizer.
     learning_rate: float = 1e-3

--- a/perseus/detector/train.py
+++ b/perseus/detector/train.py
@@ -37,7 +37,7 @@ class TrainConfig:
     learning_rate: float = 1e-3
 
     # The number of epochs to train for.
-    n_epochs: int = 1000
+    n_epochs: int = 100
 
     # The device to train on.
     device: str = "cuda" if torch.cuda.is_available() else "cpu"

--- a/perseus/detector/train.py
+++ b/perseus/detector/train.py
@@ -1,38 +1,44 @@
-import copy
-from dataclasses import dataclass
-import numpy as np
 import os
+from dataclasses import dataclass
+
+import numpy as np
 import torch
-import torch.nn as nn
+import tyro
+from torch import nn
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from tqdm import tqdm
-import tyro
-from typing import Tuple
-from wandb.util import generate_id
-import wandb
 
-from perseus.detector.models import KeypointCNN, KeypointGaussian
-from perseus.detector.data import (
-    KeypointDataset,
-    KeypointDatasetConfig,
-    AugmentationConfig,
-    KeypointAugmentation,
-)
+import wandb
+from perseus.detector.data import AugmentationConfig, KeypointAugmentation, KeypointDataset, KeypointDatasetConfig
+from perseus.detector.models import KeypointCNN, KeypointGaussian, YOLOModel
+from wandb.util import generate_id
+
+wandb.require("core")  # Use new wandb backend.
 
 
 @dataclass(frozen=True)
 class TrainConfig:
     """Configuration for training."""
 
-    # Training parameters.
+    # The batch size.
     batch_size: int = 128
+
+    # The (initial) learning rate set in the optimizer.
     learning_rate: float = 1e-3
+
+    # The number of epochs to train for.
     n_epochs: int = 100
+
+    # The device to train on.
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # The number of workers to use for data loading.
     num_workers: int = -1
 
-    output_type: str = "regression"
+    # The output type of the model.
+    output_type: str = "yolo"  # options: gaussian, regression, yolo
 
+    # Training schedule.
     val_epochs: int = 1
     print_epochs: int = 1
     save_epochs: int = 5
@@ -51,9 +57,9 @@ class TrainConfig:
     wandb_project: str = "perseus-detector"
 
 
-def train(cfg: TrainConfig):
+def train(cfg: TrainConfig) -> None:  # noqa: PLR0912, PLR0915
+    """Train a keypoint detector model."""
     # Create dataloader.
-
     train_dataset = KeypointDataset(cfg.dataset_config, train=True)
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset,
@@ -73,52 +79,40 @@ def train(cfg: TrainConfig):
         cfg.augmentation_config, train=False
     )  # Still create this to do pixel coordinate conversion.
 
-    # Initialize model.
+    # Initialize model and loss function
     if cfg.output_type == "gaussian":
-        model = KeypointGaussian(
-            cfg.n_keypoints, cfg.in_channels, train_dataset.H, train_dataset.W
-        ).to(cfg.device)
-    elif cfg.output_type == "regression":
-        model = KeypointCNN(
-            cfg.n_keypoints, cfg.in_channels, train_dataset.H, train_dataset.W
-        ).to(cfg.device)
+        model = KeypointGaussian(cfg.n_keypoints, cfg.in_channels, train_dataset.H, train_dataset.W).to(cfg.device)
 
-    # Initialize optimizer.
-    optimizer = torch.optim.Adam(model.parameters(), lr=cfg.learning_rate)
-    scheduler = ReduceLROnPlateau(
-        optimizer, "min", patience=5, factor=0.5, verbose=True
-    )
-
-    # Initialize loss function.
-    if cfg.output_type == "gaussian":
         if model.cov_type == "chol":
 
-            def loss_fn(pred, pixel_coordinates):
+            def loss_fn(pred: torch.Tensor, pixel_coordinates: torch.Tensor) -> torch.Tensor:
                 mu, L = pred
 
-                return -torch.distributions.multivariate_normal.MultivariateNormal(
-                    mu, scale_tril=L
-                ).log_prob(pixel_coordinates).mean() - (
-                    cfg.n_keypoints / 2
-                ) * torch.log(
-                    torch.tensor(2 * np.pi)
-                )
+                return -torch.distributions.multivariate_normal.MultivariateNormal(mu, scale_tril=L).log_prob(
+                    pixel_coordinates
+                ).mean() - (cfg.n_keypoints / 2) * torch.log(torch.tensor(2 * np.pi))
 
         elif model.cov_type == "diag":
 
-            def loss_fn(pred, pixel_coordinates):
+            def loss_fn(pred: torch.Tensor, pixel_coordinates: torch.Tensor) -> torch.Tensor:
                 mu, sigma = pred
 
-                return -torch.distributions.multivariate_normal.MultivariateNormal(
-                    mu, sigma
-                ).log_prob(pixel_coordinates).mean() - (
-                    cfg.n_keypoints / 2
-                ) * torch.log(
-                    torch.tensor(2 * np.pi)
-                )
+                return -torch.distributions.multivariate_normal.MultivariateNormal(mu, sigma).log_prob(
+                    pixel_coordinates
+                ).mean() - (cfg.n_keypoints / 2) * torch.log(torch.tensor(2 * np.pi))
 
     elif cfg.output_type == "regression":
+        model = KeypointCNN(cfg.n_keypoints, cfg.in_channels, train_dataset.H, train_dataset.W).to(cfg.device)
         loss_fn = nn.SmoothL1Loss(beta=1.0)
+    elif cfg.output_type == "yolo":
+        model = YOLOModel(version=10, size="n", n_keypoints=8).to(cfg.device)
+        loss_fn = nn.SmoothL1Loss(beta=1.0)
+    else:
+        raise NotImplementedError(f"Output type {cfg.output_type} not implemented.")
+
+    # Initialize optimizer.
+    optimizer = torch.optim.Adam(model.parameters(), lr=cfg.learning_rate)
+    scheduler = ReduceLROnPlateau(optimizer, "min", patience=5, factor=0.5, verbose=True)
 
     # Initialize wandb.
     wandb_id = generate_id()
@@ -133,11 +127,7 @@ def train(cfg: TrainConfig):
     for epoch in range(cfg.n_epochs):
         # Train model.
         model.train()
-        for i, example in tqdm(
-            enumerate(train_dataloader),
-            desc=f"Epoch {epoch}",
-            total=len(train_dataloader),
-        ):
+        for example in tqdm(train_dataloader, desc=f"Epoch {epoch}", total=len(train_dataloader)):
             images = example["image"]
             pixel_coordinates = example["pixel_coordinates"]
 
@@ -149,12 +139,20 @@ def train(cfg: TrainConfig):
             images, pixel_coordinates = train_augment(images, pixel_coordinates)
 
             # Forward pass.
-            pred = model(images)
+            if cfg.output_type == "yolo":
+                # the yolo model uses a dual loss - we just add the one-to-many and one-to-one paths
+                # [WARNING] this might make it hard to compare the train perf of the yolo model to the other models
+                pred_o2o, pred_o2m = model(images)
+                loss_o2o = loss_fn(pred_o2o, pixel_coordinates)
+                loss_o2m = loss_fn(pred_o2m, pixel_coordinates)
+                loss = loss_o2o + loss_o2m
+            else:
+                pred = model(images)
 
-            # TODO(pculbert): add some validation / shape checking.
+                # TODO(pculbert): add some validation / shape checking.
 
-            # Compute loss.
-            loss = loss_fn(pred, pixel_coordinates)
+                # Compute loss.
+                loss = loss_fn(pred, pixel_coordinates)
 
             # Backward pass.
             optimizer.zero_grad()
@@ -176,11 +174,7 @@ def train(cfg: TrainConfig):
             model.eval()
             with torch.no_grad():
                 val_loss = 0
-                for i, example in tqdm(
-                    enumerate(val_dataloader),
-                    desc=f"Validation",
-                    total=len(val_dataloader),
-                ):
+                for example in tqdm(val_dataloader, desc="Validation", total=len(val_dataloader)):
                     # Unpack example.
                     images = example["image"]
                     pixel_coordinates = example["pixel_coordinates"]
@@ -193,6 +187,8 @@ def train(cfg: TrainConfig):
                     images, pixel_coordinates = val_augment(images, pixel_coordinates)
 
                     # Forward pass.
+                    # [NOTE] when the model is in eval mode, the yolo model will only return the one-to-one path,
+                    # so it becomes easier to compare the performance of the yolo model to the other models
                     pred = model(images)
 
                     # Compute loss.

--- a/perseus/detector/train_yolo_nas.py
+++ b/perseus/detector/train_yolo_nas.py
@@ -15,6 +15,8 @@ from super_gradients.training.transforms.keypoints import (
     KeypointsImageStandardize,
 )
 from super_gradients.training.utils.callbacks import ExtremeBatchPoseEstimationVisualizationCallback, Phase
+
+# from super_gradients.training.utils.distributed_training_utils import setup_device
 from super_gradients.training.utils.early_stopping import EarlyStop
 from torch.utils.data import DataLoader
 
@@ -46,13 +48,13 @@ def train() -> str:
         data_dir=f"{ROOT}/data/merged.hdf5",
         transforms=train_transforms,
         train=True,
-        size=1024,  # [DEBUG]
+        # size=1024,  # [DEBUG]
     )
     val_dataset = KeypointDatasetYoloNas(
         data_dir=f"{ROOT}/data/merged.hdf5",
         transforms=val_transforms,
         train=False,
-        size=1024,  # [DEBUG]
+        # size=1024,  # [DEBUG]
     )
     print("Created datasets!")
 
@@ -121,7 +123,7 @@ def train() -> str:
         "initial_lr": 5e-4,
         "lr_mode": "cosine",
         "cosine_final_lr_ratio": 0.05,
-        "max_epochs": 1,  # [DEBUG]
+        "max_epochs": 100,
         "zero_weight_decay_on_bias_and_bn": True,
         "batch_accumulate": 1,
         "average_best_models": True,

--- a/perseus/detector/train_yolo_nas.py
+++ b/perseus/detector/train_yolo_nas.py
@@ -1,0 +1,210 @@
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from PIL import Image
+from super_gradients.common.object_names import Models
+from super_gradients.training import Trainer, models
+from super_gradients.training.datasets.pose_estimation_datasets import YoloNASPoseCollateFN
+from super_gradients.training.metrics import PoseEstimationMetrics
+from super_gradients.training.models.pose_estimation_models.yolo_nas_pose import YoloNASPosePostPredictionCallback
+from super_gradients.training.transforms.keypoints import (
+    KeypointsBrightnessContrast,
+    KeypointsHSV,
+    KeypointsImageStandardize,
+)
+from super_gradients.training.utils.callbacks import ExtremeBatchPoseEstimationVisualizationCallback, Phase
+from super_gradients.training.utils.early_stopping import EarlyStop
+from torch.utils.data import DataLoader
+
+from perseus import ROOT
+from perseus.detector.data import KeypointDatasetYoloNas
+
+# setup_device(num_gpus=torch.cuda.device_count())  # TODO(ahl): debug why this is broken
+
+
+def train() -> str:
+    """Train the YOLO NAS Pose model."""
+    # transforms
+    keypoints_hsv = KeypointsHSV(prob=0.5, hgain=20, sgain=20, vgain=20)
+    keypoints_brightness_contrast = KeypointsBrightnessContrast(
+        prob=0.5, brightness_range=[0.8, 1.2], contrast_range=[0.8, 1.2]
+    )
+    # keypoints_mosaic = KeypointsMosaic(prob=0.8)
+    keypoints_image_standardize = KeypointsImageStandardize(max_value=255)
+    train_transforms = [
+        keypoints_hsv,
+        keypoints_brightness_contrast,
+        # keypoints_mosaic,
+        keypoints_image_standardize,
+    ]
+    val_transforms = [keypoints_image_standardize]
+
+    # datasets
+    train_dataset = KeypointDatasetYoloNas(
+        data_dir=f"{ROOT}/data/merged.hdf5",
+        transforms=train_transforms,
+        train=True,
+        size=1024,  # [DEBUG]
+    )
+    val_dataset = KeypointDatasetYoloNas(
+        data_dir=f"{ROOT}/data/merged.hdf5",
+        transforms=val_transforms,
+        train=False,
+        size=1024,  # [DEBUG]
+    )
+    print("Created datasets!")
+
+    # dataloaders
+    train_dataloader_params = {
+        "shuffle": True,
+        "batch_size": 512,
+        "drop_last": True,
+        "pin_memory": True,
+        "num_workers": 4,
+        "collate_fn": YoloNASPoseCollateFN(),
+    }
+    train_dataloader = DataLoader(train_dataset, **train_dataloader_params)
+    val_dataloader_params = {
+        "shuffle": True,
+        "batch_size": 512,
+        "drop_last": True,
+        "pin_memory": True,
+        "num_workers": 4,
+        "collate_fn": YoloNASPoseCollateFN(),
+    }
+    val_dataloader = DataLoader(val_dataset, **val_dataloader_params)
+    print("Created dataloaders!")
+
+    # model
+    model = models.get(Models.YOLO_NAS_POSE_N, num_classes=8, pretrained_weights="coco_pose").cuda()
+    print("Created model!")
+
+    # training parameters
+    post_prediction_callback = YoloNASPosePostPredictionCallback(
+        pose_confidence_threshold=0.01,
+        nms_iou_threshold=0.7,
+        pre_nms_max_predictions=10,
+        post_nms_max_predictions=1,
+    )
+    metrics = PoseEstimationMetrics(
+        num_joints=8,
+        oks_sigmas=[0.07] * 8,
+        max_objects_per_image=1,
+        post_prediction_callback=post_prediction_callback,
+    )
+    visualization_callback = ExtremeBatchPoseEstimationVisualizationCallback(
+        keypoint_colors=train_dataset.keypoint_colors,
+        edge_colors=train_dataset.edge_colors,
+        edge_links=train_dataset.edge_links,
+        loss_to_monitor="YoloNASPoseLoss/loss",
+        max=True,
+        freq=1,
+        max_images=16,
+        enable_on_train_loader=True,
+        enable_on_valid_loader=True,
+        post_prediction_callback=post_prediction_callback,
+    )
+    early_stop = EarlyStop(
+        phase=Phase.VALIDATION_EPOCH_END,
+        monitor="AP",
+        mode="max",
+        min_delta=0.0001,
+        patience=100,
+        verbose=True,
+    )
+    train_params = {
+        "warmup_mode": "LinearBatchLRWarmup",
+        "warmup_initial_lr": 1e-8,
+        "lr_warmup_epochs": 2,
+        "initial_lr": 5e-4,
+        "lr_mode": "cosine",
+        "cosine_final_lr_ratio": 0.05,
+        "max_epochs": 1,  # [DEBUG]
+        "zero_weight_decay_on_bias_and_bn": True,
+        "batch_accumulate": 1,
+        "average_best_models": True,
+        "save_ckpt_epoch_list": [],
+        "loss": "yolo_nas_pose_loss",
+        "criterion_params": {
+            "oks_sigmas": [0.07] * 8,
+            "classification_loss_weight": 1.0,
+            "classification_loss_type": "focal",
+            "regression_iou_loss_type": "ciou",
+            "iou_loss_weight": 2.5,
+            "dfl_loss_weight": 0.01,
+            "pose_cls_loss_weight": 1.0,
+            "pose_reg_loss_weight": 34.0,
+            "pose_classification_loss_type": "focal",
+            "rescale_pose_loss_with_assigned_score": True,
+            "assigner_multiply_by_pose_oks": True,
+        },
+        "optimizer": "AdamW",
+        "optimizer_params": {"weight_decay": 0.000001},
+        "ema": True,
+        "ema_params": {"decay": 0.997, "decay_type": "threshold"},
+        "mixed_precision": True,
+        "sync_bn": False,
+        "valid_metrics_list": [metrics],
+        "phase_callbacks": [visualization_callback, early_stop],
+        "pre_prediction_callback": None,
+        "metric_to_watch": "AP",
+        "greater_metric_to_watch_is_better": True,
+    }
+
+    # train
+    CHECKPOINT_DIR = "test_ckpts"
+    trainer = Trainer(experiment_name="test", ckpt_root_dir=CHECKPOINT_DIR)
+    trainer.train(model=model, training_params=train_params, train_loader=train_dataloader, valid_loader=val_dataloader)
+
+    # getting best model
+    best_model_path = os.path.join(trainer.checkpoints_dir_path, "ckpt_best.pth")
+    print(80 * "=")
+    print(f"Best model path: {best_model_path}")
+    print(80 * "=")
+    return best_model_path
+
+
+def viz(best_model_path: str) -> None:
+    """Visualize the keypoint predictions of the YOLO NAS Pose model."""
+    # read the image and load it as a torch tensor
+    best_model = models.get(
+        "yolo_nas_pose_n",
+        num_classes=8,
+        checkpoint_path=best_model_path,
+    )
+    with open(f"{ROOT}/data/real_imgs/img0_a.png", "rb") as f:
+        image_np = Image.open(f).convert("RGB")
+        image = torch.tensor(np.array(image_np)).permute(2, 0, 1).float() / 255.0
+
+        # center crop the image to 256x256
+        h_crop = 256
+        w_crop = 256
+        image = image[
+            ...,
+            image.shape[-2] // 2 - h_crop // 2 : image.shape[-2] // 2 + h_crop // 2,
+            image.shape[-1] // 2 - w_crop // 2 : image.shape[-1] // 2 + w_crop // 2,
+        ]
+
+        # visualizing keypoint predictions
+        res = best_model.predict(image, conf=0.0)
+        if len(res.prediction.poses) > 0:
+            keypoints = res.prediction.poses[0][..., :2]
+            scores = res.prediction.poses[0][..., 2]
+
+            # create a colormap based on the score (from 0 to 1)
+            cmap = plt.cm.get_cmap("viridis")
+            plt.imshow(image.permute(1, 2, 0))
+            plt.scatter(keypoints[:, 0], keypoints[:, 1], c=scores, cmap=cmap)
+            cbar = plt.colorbar()
+            cbar.set_label("Confidence")
+            plt.clim(0, 1)
+            plt.title("Keypoint predictions")
+            plt.axis("off")
+            plt.show()
+
+
+if __name__ == "__main__":
+    best_model_path = train()
+    viz(best_model_path)

--- a/perseus/detector/utils.py
+++ b/perseus/detector/utils.py
@@ -1,0 +1,4 @@
+def rank_print(msg: str, rank: int = 0) -> None:
+    """Prints only if rank is 0."""
+    if rank == 0:
+        print(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "plotly>=5.18.0",
     "qasync>=0.27.1",
     "pypose>=0.6.7",
+    "tensorflow>=2.17.0",
     "ultralytics>=8.2.78",
     "wandb>=0.17.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,18 @@ dependencies = [
     "plotly>=5.18.0",
     "qasync>=0.27.1",
     "pypose>=0.6.7",
-    "tensorflow>=2.17.0",
     "ultralytics>=8.2.78",
     "wandb>=0.17.7",
 ]
 
 # optional
 [project.optional-dependencies]
+datagen = [
+    "bpy>=4.2.0",
+    "tensorflow>=2.17.0",
+]
 dev = [
+    "perseus[datagen]",
     "pre-commit>=3.7.1",
     "ruff>=0.4.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "plotly>=5.18.0",
     "qasync>=0.27.1",
     "pypose>=0.6.7",
+    "trimesh>=4.4.7",
     "ultralytics>=8.2.78",
     "super-gradients>=3.7.1",
     "wandb>=0.17.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,87 @@ dependencies = [
     "plotly>=5.18.0",
     "qasync>=0.27.1",
     "pypose>=0.6.7",
+    "ultralytics>=8.2.78",
 ]
+
+# optional
+[project.optional-dependencies]
+dev = [
+    "pre-commit>=3.7.1",
+    "ruff>=0.4.9",
+]
+
+[tool.ruff]
+line-length = 120
+respect-gitignore = false
+exclude=[
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+[tool.ruff.lint]
+pydocstyle.convention = "google"
+select = [
+    "ANN",  # annotations
+    "N",  # naming conventions
+    "D",  # docstrings
+    "B",  # flake8 bugbear
+    "E",  # pycodestyle errors
+    "F",  # Pyflakes rules
+    "I",  # isort formatting
+    "PLC",  # Pylint convention warnings
+    "PLE",  # Pylint errors
+    "PLR",  # Pylint refactor recommendations
+    "PLW",  # Pylint warnings
+]
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
+    "D100",  # missing docstring in public module
+    "D104",  # missing docstring in public package
+    "D203",  # blank line before class docstring
+    "D211",  # no blank line before class
+    "D212",  # multi-line docstring summary at first line
+    "D213",  # multi-line docstring summary at second line
+    "PLR0913",  # Too many arguments in function definition
+]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["cerberus"]
+split-on-trailing-comma = false
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+docstring-code-line-length = "dynamic"
 
 [tool.hatch.build.targets.wheel]
 include = ["perseus*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ ignore = [
     "D212",  # multi-line docstring summary at first line
     "D213",  # multi-line docstring summary at second line
     "PLR0913",  # Too many arguments in function definition
+    "N803",  # Argument name <argument> should be lowercase
+    "N806",  # Variable in function should be lowercase
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "torchvision>=0.16.2",
     "kornia>=0.7.1",
     "gtsam>=4.2",
+    "h5py>=3.11.0",
     "opencv-python>=4.9.0.80",
     "pyqt5>=5.15.10",
     "pyqtgraph>=0.13.3",
@@ -28,6 +29,7 @@ dependencies = [
     "qasync>=0.27.1",
     "pypose>=0.6.7",
     "ultralytics>=8.2.78",
+    "wandb>=0.17.7",
 ]
 
 # optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 # optional
 [project.optional-dependencies]
 datagen = [
-    "bpy>=4.2.0",
+    "bpy==3.6.0",
     "openexr>=3.2.4",
     "pybullet>=3.2.6",
     "tensorflow>=2.17.0",
@@ -121,4 +121,4 @@ docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
 [tool.hatch.build.targets.wheel]
-include = ["perseus*"]
+include = ["perseus*", "kubric*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 datagen = [
     "bpy>=4.2.0",
+    "openexr>=3.2.4",
     "pybullet>=3.2.6",
     "tensorflow>=2.17.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 urls = { "Homepage" = "https://github.com/pculbertson/perseus" }
 dependencies = [
-    "numpy>=1.26.3",
+    "numpy>=1.23.0",
     "torch>=2.1.1",
     "torchvision>=0.16.2",
     "kornia>=0.7.1",
@@ -29,6 +29,7 @@ dependencies = [
     "qasync>=0.27.1",
     "pypose>=0.6.7",
     "ultralytics>=8.2.78",
+    "super-gradients>=3.7.1",
     "wandb>=0.17.7",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 datagen = [
     "bpy>=4.2.0",
+    "pybullet>=3.2.6",
     "tensorflow>=2.17.0",
 ]
 dev = [


### PR DESCRIPTION
Adds the Yolo model with a keypoint detection head and assorted changes to prepare for including depth data.

### Notes
* After preliminary training, I've determined that the YOLO model will probably not be easier to tune/train than our existing model, even with a larger dataset size.

### Changes
* Bugfix: address different training vs. eval outputs of yolo detector model in our training loop
* Added linters
* Created new YOLO model
* Assorted changes to the training loop:
    * multi-gpu training
    * along with multi-gpu, dataloader shenanigans (num_workers, pin_memory, multiprocessing_context)
    * automatic mixed precision
    * model compilation
    * gradient scaler
* Upgrades to datagen code, fully fleshed out including depth and segmentation images (`__getitem__` returns a binary mask of the cube now) in datasets
* Added script to programmatically merge together many smaller datasets generated from Preston's datagen scripts
* Added the option to do lazy dataloading (was necessary for multigpu with YOLO, but I'm not a fan of the lazy dataloading or the YOLO model training, so this won't really be used for now)

### Old YOLO TODOs
* Fix up training loop with bells and whistles
    * prefetch_factor
    * flag to cache/load data into RAM
* check why multigpu slows down training
* Potentially update the augmentations with some of the argus augmentations
* Mess with loss function potentially - use the o2m and o2o consistency loss in the yolov10 paper?
* [HIGH PRIO] Supervise cube detections with the yolo model as well - the current model doesn't learn the keypoint locations (we check vs. our original keypoint detection model)